### PR TITLE
formspree.io instead of brace.io

### DIFF
--- a/contact/index.html
+++ b/contact/index.html
@@ -23,7 +23,7 @@ category: contact
     </em>
   </p>
 
-  <form action="//forms.brace.io/seb@saunier.me" role="form" method="POST">
+  <form action="//formspree.io/seb@saunier.me" role="form" method="POST">
     <div class="form-group">
       <label for="name">What's your name?</label>
       <input type="text" name="name" class="form-control" required>


### PR DESCRIPTION
First of all thank you for your article about formspree. I've just built my own blog in Jekyll and I want to embed a contact form for my blog.
I noticed that you have not updated your form. You did not change brace.io to formspree.io. Did it work until today? When I try it they say "This Site44-hosted website has been temporarily suspended due to excessive usage. If you are the owner of this site, please log in to the Site44 admin page.". Hope it did work until today for you but I guess not...

Stéphane, student at Simplon.co
